### PR TITLE
Lock the action to the last stable docker container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://gcr.io/tidal-1529434400027/tidal-tools:latest'
+  image: 'docker://gcr.io/tidal-1529434400027/tidal-tools:last-stable'
   args:
     - --tidal-email
     - '${{ inputs.tidal-email }}'

--- a/doctor/action.yml
+++ b/doctor/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'gcr.io/tidal-1529434400027/tidal-tools:latest'
+  image: 'gcr.io/tidal-1529434400027/tidal-tools:last-stable'
   args:
     - 'doctor'
     - '--tidal-email'

--- a/ping/action.yml
+++ b/ping/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'gcr.io/tidal-1529434400027/tidal-tools:latest'
+  image: 'gcr.io/tidal-1529434400027/tidal-tools:last-stable'
   args:
     - 'ping'
     - '--tidal-email'


### PR DESCRIPTION
The failing checks in this repo appear to be related to changes in tidal-tools in the way secrets are passed to the CLI. The action itself still works correctly. I'll circle back and deal with the checks once I get some more info on the problem.