### PR TITLE
chore: add .npmrc with min-release-age=3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
Adds `min-release-age=3` to `.npmrc` so freshly published packages cannot be installed for 3 days. Supply-chain hardening measure applied org-wide.